### PR TITLE
handle burn amount and next round's funds

### DIFF
--- a/contracts/IERC20Burnable.sol
+++ b/contracts/IERC20Burnable.sol
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.6.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20Burnable {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * IMPORTANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+
+
+    function burn(uint256 amount) external virtual;
+}

--- a/contracts/Lottery.sol
+++ b/contracts/Lottery.sol
@@ -18,7 +18,7 @@ contract Lottery is LotteryOwnable, Initializable {
 
     uint8 constant keyLengthForEachBuy = 11;
     // Allocation for first/sencond/third reward
-    uint8[3] public allocation;
+    uint8[5] public allocation;
     // The TOKEN to buy lottery
     IERC20 public cake;
     // The Lottery NFT for tickets
@@ -29,6 +29,9 @@ contract Lottery is LotteryOwnable, Initializable {
     uint8 public maxNumber;
     // minPrice, if decimal is not 18, please reset it
     uint256 public minPrice;
+
+
+    address constant burnAddress = 0x000000000000000000000000000000000000dEaD;
 
     // =================================
 
@@ -80,7 +83,8 @@ contract Lottery is LotteryOwnable, Initializable {
         maxNumber = _maxNumber;
         adminAddress = _adminAddress;
         lastTimestamp = block.timestamp;
-        allocation = [60, 20, 10];
+        // 4 match, 3 match, 2 match, next round, burn
+        allocation = [40, 20, 10, 20, 10];
         initOwner(_owner);
     }
 
@@ -112,10 +116,17 @@ contract Lottery is LotteryOwnable, Initializable {
         winningNumbers[3]=0;
         drawingPhase = false;
         issueIndex = issueIndex +1;
-        if(getMatchingRewardAmount(issueIndex-1, 4) == 0) {
-            uint256 amount = getTotalRewards(issueIndex-1).mul(allocation[0]).div(100);
-            internalBuy(amount, nullTicket);
-        }
+        
+        uint256 amount = getTotalRewards(issueIndex-1).mul(allocation[3]).div(100);
+        if(getMatchingRewardAmount(issueIndex-1, 4) == 0)
+            amount = getTotalRewards(issueIndex-1).mul(allocation[0]).div(100);
+        
+        // burn leftovers
+        uint256 burnAmount = cake.balanceOf(address(this)).sub(amount);
+        cake.safeTransfer(burnAddress, burnAmount);
+        
+        internalBuy(amount, nullTicket);
+        
         emit Reset(issueIndex);
     }
 
@@ -371,12 +382,6 @@ contract Lottery is LotteryOwnable, Initializable {
         adminAddress = _adminAddress;
     }
 
-    // Withdraw without caring about rewards. EMERGENCY ONLY.
-    function adminWithdraw(uint256 _amount) public onlyAdmin {
-        cake.safeTransfer(address(msg.sender), _amount);
-        emit DevWithdraw(msg.sender, _amount);
-    }
-
     // Set the minimum price for one ticket
     function setMinPrice(uint256 _price) external onlyAdmin {
         minPrice = _price;
@@ -388,9 +393,10 @@ contract Lottery is LotteryOwnable, Initializable {
     }
 
     // Set the allocation for one reward
-    function setAllocation(uint8 _allcation1, uint8 _allcation2, uint8 _allcation3) external onlyAdmin {
-        require (_allcation1 + _allcation2 + _allcation3 < 100, 'exceed 100');
-        allocation = [_allcation1, _allcation2, _allcation3];
+    function setAllocation(uint8 _allcation1, uint8 _allcation2, uint8 _allcation3, uint8 _allcation4) external onlyAdmin {
+        uint256 total = uint256(_allcation1) + _allcation2 + _allcation3 + _allcation4;
+        require (total < 100, "exceed 100");
+        allocation = [_allcation1, _allcation2, _allcation3, _allcation4, uint8(100 - total)];
     }
 
 }

--- a/contracts/Lottery.sol
+++ b/contracts/Lottery.sol
@@ -3,8 +3,8 @@ pragma experimental ABIEncoderV2;
 
 import "./LotteryNFT.sol";
 import "./LotteryOwnable.sol";
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
+import "./IERC20Burnable.sol";
+import "./SafeERC20Burnable.sol";
 import "@openzeppelin/contracts/math/SafeMath.sol";
 import "@openzeppelin/contracts/proxy/Initializable.sol";
 
@@ -14,13 +14,13 @@ import "@openzeppelin/contracts/proxy/Initializable.sol";
 contract Lottery is LotteryOwnable, Initializable {
     using SafeMath for uint256;
     using SafeMath for uint8;
-    using SafeERC20 for IERC20;
+    using SafeERC20Burnable for IERC20Burnable;
 
     uint8 constant keyLengthForEachBuy = 11;
     // Allocation for first/sencond/third reward
     uint8[5] public allocation;
     // The TOKEN to buy lottery
-    IERC20 public cake;
+    IERC20Burnable public cake;
     // The Lottery NFT for tickets
     LotteryNFT public lotteryNFT;
     // adminAddress
@@ -70,7 +70,7 @@ contract Lottery is LotteryOwnable, Initializable {
     }
 
     function initialize(
-        IERC20 _cake,
+        IERC20Burnable _cake,
         LotteryNFT _lottery,
         uint256 _minPrice,
         uint8 _maxNumber,
@@ -123,7 +123,7 @@ contract Lottery is LotteryOwnable, Initializable {
         
         // burn leftovers
         uint256 burnAmount = cake.balanceOf(address(this)).sub(amount);
-        cake.safeTransfer(burnAddress, burnAmount);
+        cake.burn(burnAmount);
         
         internalBuy(amount, nullTicket);
         
@@ -393,6 +393,7 @@ contract Lottery is LotteryOwnable, Initializable {
     }
 
     // Set the allocation for one reward
+    // 4 match, 3 match, 2 match, next round, burn
     function setAllocation(uint8 _allcation1, uint8 _allcation2, uint8 _allcation3, uint8 _allcation4) external onlyAdmin {
         uint256 total = uint256(_allcation1) + _allcation2 + _allcation3 + _allcation4;
         require (total < 100, "exceed 100");

--- a/contracts/SafeERC20Burnable.sol
+++ b/contracts/SafeERC20Burnable.sol
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.6.0 <0.8.0;
+
+import "./IERC20Burnable.sol";
+import "@openzeppelin/contracts/math/SafeMath.sol";
+import "@openzeppelin/contracts/utils/Address.sol";
+
+/**
+ * @title SafeERC20
+ * @dev Wrappers around ERC20 operations that throw on failure (when the token
+ * contract returns false). Tokens that return no value (and instead revert or
+ * throw on failure) are also supported, non-reverting calls are assumed to be
+ * successful.
+ * To use this library you can add a `using SafeERC20 for IERC20;` statement to your contract,
+ * which allows you to call the safe operations as `token.safeTransfer(...)`, etc.
+ */
+library SafeERC20Burnable {
+    using SafeMath for uint256;
+    using Address for address;
+
+    function safeTransfer(IERC20Burnable token, address to, uint256 value) internal {
+        _callOptionalReturn(token, abi.encodeWithSelector(token.transfer.selector, to, value));
+    }
+
+    function safeTransferFrom(IERC20Burnable token, address from, address to, uint256 value) internal {
+        _callOptionalReturn(token, abi.encodeWithSelector(token.transferFrom.selector, from, to, value));
+    }
+
+    /**
+     * @dev Deprecated. This function has issues similar to the ones found in
+     * {IERC20Burnable-approve}, and its usage is discouraged.
+     *
+     * Whenever possible, use {safeIncreaseAllowance} and
+     * {safeDecreaseAllowance} instead.
+     */
+    function safeApprove(IERC20Burnable token, address spender, uint256 value) internal {
+        // safeApprove should only be called when setting an initial allowance,
+        // or when resetting it to zero. To increase and decrease it, use
+        // 'safeIncreaseAllowance' and 'safeDecreaseAllowance'
+        // solhint-disable-next-line max-line-length
+        require((value == 0) || (token.allowance(address(this), spender) == 0),
+            "SafeERC20: approve from non-zero to non-zero allowance"
+        );
+        _callOptionalReturn(token, abi.encodeWithSelector(token.approve.selector, spender, value));
+    }
+
+    function safeIncreaseAllowance(IERC20Burnable token, address spender, uint256 value) internal {
+        uint256 newAllowance = token.allowance(address(this), spender).add(value);
+        _callOptionalReturn(token, abi.encodeWithSelector(token.approve.selector, spender, newAllowance));
+    }
+
+    function safeDecreaseAllowance(IERC20Burnable token, address spender, uint256 value) internal {
+        uint256 newAllowance = token.allowance(address(this), spender).sub(value, "SafeERC20: decreased allowance below zero");
+        _callOptionalReturn(token, abi.encodeWithSelector(token.approve.selector, spender, newAllowance));
+    }
+
+    /**
+     * @dev Imitates a Solidity high-level call (i.e. a regular function call to a contract), relaxing the requirement
+     * on the return value: the return value is optional (but if data is returned, it must not be false).
+     * @param token The token targeted by the call.
+     * @param data The call data (encoded using abi.encode or one of its variants).
+     */
+    function _callOptionalReturn(IERC20Burnable token, bytes memory data) private {
+        // We need to perform a low level call here, to bypass Solidity's return data size checking mechanism, since
+        // we're implementing it ourselves. We use {Address.functionCall} to perform this call, which verifies that
+        // the target address contains contract code and also asserts for success in the low-level call.
+
+        bytes memory returndata = address(token).functionCall(data, "SafeERC20: low-level call failed");
+        if (returndata.length > 0) { // Return data is optional
+            // solhint-disable-next-line max-line-length
+            require(abi.decode(returndata, (bool)), "SafeERC20: ERC20 operation did not succeed");
+        }
+    }
+}


### PR DESCRIPTION
modified code to handle burn mount and next round's funds.
modifications do this:

- if there is no 4 matching ticket, transfer those prize to next round and burn leftovers
- if there is 4 matching ticket, transfer predefined percentage of funds to next round and burn leftovers 

deleted emergencyWithdraw btw.

didn't tried yet but it compiles successfully.